### PR TITLE
Integrate `shirokuma`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "p2panda-js": "^0.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.3.0"
+        "react-router-dom": "^6.3.0",
+        "shirokuma": "file:../shirokuma"
       },
       "devDependencies": {
         "@types/mini-css-extract-plugin": "^2.5.1",
@@ -39,6 +40,52 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.0",
         "yargs": "^17.5.1"
+      }
+    },
+    "../shirokuma": {
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "graphql": "^16.5.0",
+        "graphql-request": "^4.3.0",
+        "p2panda-js": "^0.5.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.18.10",
+        "@babel/core": "^7.18.10",
+        "@babel/preset-env": "^7.18.10",
+        "@babel/register": "^7.18.9",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.2",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.4",
+        "@tsconfig/node16": "^1.0.3",
+        "@types/jest": "^28.1.6",
+        "@types/node": "^18.7.3",
+        "@typescript-eslint/eslint-plugin": "^5.33.0",
+        "@typescript-eslint/parser": "^5.33.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "fetch-mock-jest": "^1.5.1",
+        "jest": "^28.1.3",
+        "nodemon": "^2.0.19",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.7.1",
+        "rimraf": "^3.0.2",
+        "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-terser": "^7.0.2",
+        "ts-jest": "^28.0.7",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
+      },
+      "engines": {
+        "node": ">= v16.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -5643,6 +5690,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/shirokuma": {
+      "resolved": "../shirokuma",
+      "link": true
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -10960,6 +11011,46 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shirokuma": {
+      "version": "file:../shirokuma",
+      "requires": {
+        "@babel/cli": "^7.18.10",
+        "@babel/core": "^7.18.10",
+        "@babel/preset-env": "^7.18.10",
+        "@babel/register": "^7.18.9",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.2",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.4",
+        "@tsconfig/node16": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@types/jest": "^28.1.6",
+        "@types/node": "^18.7.3",
+        "@typescript-eslint/eslint-plugin": "^5.33.0",
+        "@typescript-eslint/parser": "^5.33.0",
+        "cross-env": "^7.0.3",
+        "debug": "^4.3.4",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "fetch-mock-jest": "^1.5.1",
+        "graphql": "^16.5.0",
+        "graphql-request": "^4.3.0",
+        "jest": "^28.1.3",
+        "nodemon": "^2.0.19",
+        "npm-run-all": "^4.1.5",
+        "p2panda-js": "^0.5.0",
+        "prettier": "^2.7.1",
+        "rimraf": "^3.0.2",
+        "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-terser": "^7.0.2",
+        "ts-jest": "^28.0.7",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "p2panda-js": "^0.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "shirokuma": "file:../shirokuma"
   },
   "devDependencies": {
     "@types/mini-css-extract-plugin": "^2.5.1",

--- a/src/P2pandaContext.tsx
+++ b/src/P2pandaContext.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { KeyPair } from 'p2panda-js';
+import { KeyPair, Session } from 'shirokuma';
+import { ENDPOINT } from './constants';
 
 const LOCAL_STORAGE_KEY = 'privateKey';
 
@@ -17,28 +18,32 @@ function getKeyPair(): KeyPair {
 type Context = {
   publicKey: string | null;
   keyPair: KeyPair | null;
+  session: Session | null;
 };
 
-export const KeyPairContext = React.createContext<Context>({
+export const P2pandaContext = React.createContext<Context>({
   publicKey: null,
   keyPair: null,
+  session: null,
 });
 
 type Props = {
   children: JSX.Element;
 };
 
-export const KeyPairProvider: React.FC<Props> = ({ children }) => {
+export const P2pandaProvider: React.FC<Props> = ({ children }) => {
   const state = useMemo(() => {
     const keyPair = getKeyPair();
+    const session = new Session(ENDPOINT).setKeyPair(keyPair);
 
     return {
       keyPair,
       publicKey: keyPair.publicKey(),
+      session,
     };
   }, []);
 
   return (
-    <KeyPairContext.Provider value={state}>{children}</KeyPairContext.Provider>
+    <P2pandaContext.Provider value={state}>{children}</P2pandaContext.Provider>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
 import { Navigation } from '.';
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 
 export const Header: React.FC = () => {
   return (
     <header>
       <h1>🐼 🍄</h1>
-      <KeyPairContext.Consumer>
+      <P2pandaContext.Consumer>
         {({ publicKey }) => {
           return <p className="public-key">Hello, {publicKey}!</p>;
         }}
-      </KeyPairContext.Consumer>
+      </P2pandaContext.Consumer>
       <Navigation />
     </header>
   );

--- a/src/components/InitWasm.tsx
+++ b/src/components/InitWasm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { initWebAssembly } from 'p2panda-js';
+import { initWebAssembly } from 'shirokuma';
 
 type Props = {
   children: JSX.Element;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,18 +5,18 @@ import { createRoot } from 'react-dom/client';
 import './styles.css';
 
 import { App, InitWasm } from './components';
-import { KeyPairProvider } from './KeyPairContext';
+import { P2pandaProvider } from './P2pandaContext';
 import { Router } from './Router';
 
 const Root: React.FC = () => {
   return (
     <InitWasm>
       <BrowserRouter>
-        <KeyPairProvider>
+        <P2pandaProvider>
           <App>
             <Router />
           </App>
-        </KeyPairProvider>
+        </P2pandaProvider>
       </BrowserRouter>
     </InitWasm>
   );

--- a/src/views/AddMushroom.tsx
+++ b/src/views/AddMushroom.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { Mushroom } from '../types';
 import { createMushroom } from '../requests';
 
 export const AddMushroom = () => {
   const navigate = useNavigate();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [values, setValues] = useState<Mushroom>({
     title: '',
@@ -31,7 +31,7 @@ export const AddMushroom = () => {
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await createMushroom(keyPair, values);
+    await createMushroom(session, values);
     window.alert('Created mushroom!');
     navigate('/mushrooms');
   };

--- a/src/views/EditMushroom.tsx
+++ b/src/views/EditMushroom.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { getMushroom, updateMushroom } from '../requests';
 import { Mushroom } from '../types';
 
 export const EditMushroom = () => {
   const navigate = useNavigate();
   const { documentId } = useParams();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [loading, setLoading] = useState(true);
   const [viewId, setViewId] = useState<string>();
@@ -46,7 +46,7 @@ export const EditMushroom = () => {
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await updateMushroom(keyPair, viewId, values);
+    await updateMushroom(session, viewId, values);
     window.alert('Updated mushroom!');
     navigate('/mushrooms');
   };

--- a/src/views/UploadPicture.tsx
+++ b/src/views/UploadPicture.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { Picture } from '../types';
 import { createPicture, getAllMushrooms } from '../requests';
 
 export const UploadPicture = () => {
   const navigate = useNavigate();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [values, setValues] = useState<Picture>({
     blob: '',
@@ -59,7 +59,7 @@ export const UploadPicture = () => {
 
   const onSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    await createPicture(keyPair, values);
+    await createPicture(session, values);
     window.alert('Uploaded picture!');
     navigate('/pictures');
   };


### PR DESCRIPTION
Integrate the higher level p2panda lib `shirokuma.

We shouldn't actually merge this to main as it would mess up the existing tutorial, but maybe there is a home for it elsewhere eventually.

- [x] import `shirokuma` (currently from local build, requires https://github.com/p2panda/shirokuma/tree/update-api)
- [x] expose `Session` globally via context
- [x] use `session` to create and update documents
- [x] use `session` to publish the schema too
  - [x]  needs access to the newly created document id's though, which `session` doesn't currently give
- [x] figure out why publishing a `Picture` currently fails with `Error: Unsupported field type: object`