### PR TITLE
Use `shirokuma` instead of `p2panda-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
-        "shirokuma": "file:../shirokuma"
+        "shirokuma": "^0.1.2"
       },
       "devDependencies": {
         "@types/mini-css-extract-plugin": "^2.5.1",
@@ -42,50 +42,17 @@
         "yargs": "^17.5.1"
       }
     },
-    "../shirokuma": {
-      "version": "0.1.0",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@types/debug": "^4.1.7",
-        "debug": "^4.3.4",
-        "graphql": "^16.5.0",
-        "graphql-request": "^4.3.0",
-        "p2panda-js": "^0.5.0"
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
-      "devDependencies": {
-        "@babel/cli": "^7.18.10",
-        "@babel/core": "^7.18.10",
-        "@babel/preset-env": "^7.18.10",
-        "@babel/register": "^7.18.9",
-        "@rollup/plugin-babel": "^5.3.1",
-        "@rollup/plugin-commonjs": "^22.0.2",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-typescript": "^8.3.4",
-        "@tsconfig/node16": "^1.0.3",
-        "@types/jest": "^28.1.6",
-        "@types/node": "^18.7.3",
-        "@typescript-eslint/eslint-plugin": "^5.33.0",
-        "@typescript-eslint/parser": "^5.33.0",
-        "cross-env": "^7.0.3",
-        "eslint": "^8.22.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.2.1",
-        "fetch-mock-jest": "^1.5.1",
-        "jest": "^28.1.3",
-        "nodemon": "^2.0.19",
-        "npm-run-all": "^4.1.5",
-        "prettier": "^2.7.1",
-        "rimraf": "^3.0.2",
-        "rollup-plugin-dts": "^4.2.2",
-        "rollup-plugin-terser": "^7.0.2",
-        "ts-jest": "^28.0.7",
-        "ts-node": "^10.9.1",
-        "typedoc": "^0.23.10",
-        "typescript": "^4.7.4"
-      },
-      "engines": {
-        "node": ">= v16.0.0"
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -177,11 +144,11 @@
       "dev": true
     },
     "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3354,6 +3321,17 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/graphql-web-lite": {
+      "version": "16.6.0-4",
+      "resolved": "https://registry.npmjs.org/graphql-web-lite/-/graphql-web-lite-16.6.0-4.tgz",
+      "integrity": "sha512-A6i7IoZ/E1zB4q16W+64lGUtu9cepL4oyFjRHvZbFZkixMsSscGQs0Bx0hAHY7LucEzVc5pEkbMVf0kx/EUAiw==",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -5691,8 +5669,29 @@
       }
     },
     "node_modules/shirokuma": {
-      "resolved": "../shirokuma",
-      "link": true
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shirokuma/-/shirokuma-0.1.2.tgz",
+      "integrity": "sha512-IaXPP+dxlKGU427LAnZnsDhCPZ7mycv7lr4nFmn9+g3ctXY/OxUzrEUADd7y1Kbg7tbdfgwWd8QLbiTwLCiSMA==",
+      "dependencies": {
+        "graphql-request": "^6.1.0",
+        "graphql-web-lite": "^16.6.0-4",
+        "p2panda-js": "^0.8.0"
+      },
+      "engines": {
+        "node": ">= v18"
+      }
+    },
+    "node_modules/shirokuma/node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -6864,6 +6863,12 @@
     }
   },
   "dependencies": {
+    "@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "requires": {}
+    },
     "@babel/runtime": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
@@ -6934,9 +6939,9 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -9327,6 +9332,14 @@
         "form-data": "^3.0.0"
       }
     },
+    "graphql-web-lite": {
+      "version": "16.6.0-4",
+      "resolved": "https://registry.npmjs.org/graphql-web-lite/-/graphql-web-lite-16.6.0-4.tgz",
+      "integrity": "sha512-A6i7IoZ/E1zB4q16W+64lGUtu9cepL4oyFjRHvZbFZkixMsSscGQs0Bx0hAHY7LucEzVc5pEkbMVf0kx/EUAiw==",
+      "requires": {
+        "@0no-co/graphql.web": "^1.0.0"
+      }
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11013,43 +11026,24 @@
       "dev": true
     },
     "shirokuma": {
-      "version": "file:../shirokuma",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shirokuma/-/shirokuma-0.1.2.tgz",
+      "integrity": "sha512-IaXPP+dxlKGU427LAnZnsDhCPZ7mycv7lr4nFmn9+g3ctXY/OxUzrEUADd7y1Kbg7tbdfgwWd8QLbiTwLCiSMA==",
       "requires": {
-        "@babel/cli": "^7.18.10",
-        "@babel/core": "^7.18.10",
-        "@babel/preset-env": "^7.18.10",
-        "@babel/register": "^7.18.9",
-        "@rollup/plugin-babel": "^5.3.1",
-        "@rollup/plugin-commonjs": "^22.0.2",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-typescript": "^8.3.4",
-        "@tsconfig/node16": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@types/jest": "^28.1.6",
-        "@types/node": "^18.7.3",
-        "@typescript-eslint/eslint-plugin": "^5.33.0",
-        "@typescript-eslint/parser": "^5.33.0",
-        "cross-env": "^7.0.3",
-        "debug": "^4.3.4",
-        "eslint": "^8.22.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.2.1",
-        "fetch-mock-jest": "^1.5.1",
-        "graphql": "^16.5.0",
-        "graphql-request": "^4.3.0",
-        "jest": "^28.1.3",
-        "nodemon": "^2.0.19",
-        "npm-run-all": "^4.1.5",
-        "p2panda-js": "^0.5.0",
-        "prettier": "^2.7.1",
-        "rimraf": "^3.0.2",
-        "rollup-plugin-dts": "^4.2.2",
-        "rollup-plugin-terser": "^7.0.2",
-        "ts-jest": "^28.0.7",
-        "ts-node": "^10.9.1",
-        "typedoc": "^0.23.10",
-        "typescript": "^4.7.4"
+        "graphql-request": "^6.1.0",
+        "graphql-web-lite": "^16.6.0-4",
+        "p2panda-js": "^0.8.0"
+      },
+      "dependencies": {
+        "graphql-request": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+          "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.2.0",
+            "cross-fetch": "^3.1.5"
+          }
+        }
       }
     },
     "side-channel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "p2panda-js": "^0.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.3.0"
+        "react-router-dom": "^6.3.0",
+        "shirokuma": "file:../shirokuma"
       },
       "devDependencies": {
         "@types/mini-css-extract-plugin": "^2.5.1",
@@ -39,6 +40,52 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.0",
         "yargs": "^17.5.1"
+      }
+    },
+    "../shirokuma": {
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "graphql": "^16.5.0",
+        "graphql-request": "^4.3.0",
+        "p2panda-js": "^0.5.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.18.10",
+        "@babel/core": "^7.18.10",
+        "@babel/preset-env": "^7.18.10",
+        "@babel/register": "^7.18.9",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.2",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.4",
+        "@tsconfig/node16": "^1.0.3",
+        "@types/jest": "^28.1.6",
+        "@types/node": "^18.7.3",
+        "@typescript-eslint/eslint-plugin": "^5.33.0",
+        "@typescript-eslint/parser": "^5.33.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "fetch-mock-jest": "^1.5.1",
+        "jest": "^28.1.3",
+        "nodemon": "^2.0.19",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.7.1",
+        "rimraf": "^3.0.2",
+        "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-terser": "^7.0.2",
+        "ts-jest": "^28.0.7",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
+      },
+      "engines": {
+        "node": ">= v16.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -5643,6 +5690,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/shirokuma": {
+      "resolved": "../shirokuma",
+      "link": true
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -10960,6 +11011,46 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shirokuma": {
+      "version": "file:../shirokuma",
+      "requires": {
+        "@babel/cli": "^7.18.10",
+        "@babel/core": "^7.18.10",
+        "@babel/preset-env": "^7.18.10",
+        "@babel/register": "^7.18.9",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.2",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.4",
+        "@tsconfig/node16": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@types/jest": "^28.1.6",
+        "@types/node": "^18.7.3",
+        "@typescript-eslint/eslint-plugin": "^5.33.0",
+        "@typescript-eslint/parser": "^5.33.0",
+        "cross-env": "^7.0.3",
+        "debug": "^4.3.4",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "fetch-mock-jest": "^1.5.1",
+        "graphql": "^16.5.0",
+        "graphql-request": "^4.3.0",
+        "jest": "^28.1.3",
+        "nodemon": "^2.0.19",
+        "npm-run-all": "^4.1.5",
+        "p2panda-js": "^0.5.0",
+        "prettier": "^2.7.1",
+        "rimraf": "^3.0.2",
+        "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-terser": "^7.0.2",
+        "ts-jest": "^28.0.7",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "graphql": "^16.6.0",
         "graphql-request": "^5.0.0",
-        "p2panda-js": "^0.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
-    "shirokuma": "file:../shirokuma"
+    "shirokuma": "^0.1.2"
   },
   "devDependencies": {
     "@types/mini-css-extract-plugin": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
-    "p2panda-js": "^0.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "p2panda-js": "^0.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "shirokuma": "file:../shirokuma"
   },
   "devDependencies": {
     "@types/mini-css-extract-plugin": "^2.5.1",

--- a/src/P2pandaContext.tsx
+++ b/src/P2pandaContext.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { KeyPair } from 'p2panda-js';
+import { KeyPair, Session } from 'shirokuma';
+import { ENDPOINT } from './constants';
 
 const LOCAL_STORAGE_KEY = 'privateKey';
 
@@ -17,28 +18,32 @@ function getKeyPair(): KeyPair {
 type Context = {
   publicKey: string | null;
   keyPair: KeyPair | null;
+  session: Session | null;
 };
 
-export const KeyPairContext = React.createContext<Context>({
+export const P2pandaContext = React.createContext<Context>({
   publicKey: null,
   keyPair: null,
+  session: null,
 });
 
 type Props = {
   children: JSX.Element;
 };
 
-export const KeyPairProvider: React.FC<Props> = ({ children }) => {
+export const P2pandaProvider: React.FC<Props> = ({ children }) => {
   const state = useMemo(() => {
     const keyPair = getKeyPair();
+    const session = new Session(ENDPOINT).setKeyPair(keyPair);
 
     return {
       keyPair,
       publicKey: keyPair.publicKey(),
+      session,
     };
   }, []);
 
   return (
-    <KeyPairContext.Provider value={state}>{children}</KeyPairContext.Provider>
+    <P2pandaContext.Provider value={state}>{children}</P2pandaContext.Provider>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
 import { Navigation } from '.';
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 
 export const Header: React.FC = () => {
   return (
     <header>
       <h1>🐼 🍄</h1>
-      <KeyPairContext.Consumer>
+      <P2pandaContext.Consumer>
         {({ publicKey }) => {
           return <p className="public-key">Hello, {publicKey}!</p>;
         }}
-      </KeyPairContext.Consumer>
+      </P2pandaContext.Consumer>
       <Navigation />
     </header>
   );

--- a/src/components/InitWasm.tsx
+++ b/src/components/InitWasm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { initWebAssembly } from 'p2panda-js';
+import { initWebAssembly } from 'shirokuma';
 
 type Props = {
   children: JSX.Element;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,18 +5,18 @@ import { createRoot } from 'react-dom/client';
 import './styles.css';
 
 import { App, InitWasm } from './components';
-import { KeyPairProvider } from './KeyPairContext';
+import { P2pandaProvider } from './P2pandaContext';
 import { Router } from './Router';
 
 const Root: React.FC = () => {
   return (
     <InitWasm>
       <BrowserRouter>
-        <KeyPairProvider>
+        <P2pandaProvider>
           <App>
             <Router />
           </App>
-        </KeyPairProvider>
+        </P2pandaProvider>
       </BrowserRouter>
     </InitWasm>
   );

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient, gql, RequestDocument } from 'graphql-request';
-import { Session } from 'shirokuma';
+import { OperationFields, Session } from 'shirokuma';
 
 import { ENDPOINT, MUSHROOM_SCHEMA_ID, FINDINGS_SCHEMA_ID } from './constants';
 
@@ -97,7 +97,7 @@ export async function createMushroom(
   session: Session,
   values: Mushroom,
 ): Promise<void> {
-  await session.create(values, { schema: MUSHROOM_SCHEMA_ID });
+  await session.create(values, { schemaId: MUSHROOM_SCHEMA_ID });
 }
 
 export async function updateMushroom(
@@ -106,7 +106,7 @@ export async function updateMushroom(
   values: Mushroom,
 ): Promise<void> {
   await session.update(values, previous.split('_'), {
-    schema: MUSHROOM_SCHEMA_ID,
+    schemaId: MUSHROOM_SCHEMA_ID,
   });
 }
 
@@ -146,5 +146,12 @@ export async function getAllPictures(): Promise<PictureResponse[]> {
 }
 
 export async function createPicture(session: Session, values: Picture) {
-  await session.create(values, { schema: FINDINGS_SCHEMA_ID });
+  const easy_values = {
+    lat: values.lat,
+    lon: values.lon,
+  };
+  const operation_fields = new OperationFields(easy_values);
+  operation_fields.insert('blob', 'str', values.blob);
+  operation_fields.insert('mushrooms', 'relation_list', values.mushrooms);
+  await session.create(operation_fields, { schemaId: FINDINGS_SCHEMA_ID });
 }

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -6,7 +6,6 @@ import { ENDPOINT, MUSHROOM_SCHEMA_ID, FINDINGS_SCHEMA_ID } from './constants';
 import type {
   Mushroom,
   MushroomResponse,
-  NextArgs,
   Picture,
   PictureResponse,
 } from './types.d';
@@ -24,29 +23,6 @@ async function request(query: RequestDocument, variables?: any) {
       'Error: Could not connect to node.\n\n- Did you start the node at port `2020`?\n- Did you deploy the schemas (via `npm run schema`) and changed the schema ids in `./src/constants.ts`?',
     );
   }
-}
-
-export async function publish(
-  entry: string,
-  operation: string,
-): Promise<NextArgs> {
-  const query = gql`
-    mutation Publish($entry: String!, $operation: String!) {
-      publish(entry: $entry, operation: $operation) {
-        logId
-        seqNum
-        backlink
-        skiplink
-      }
-    }
-  `;
-
-  const result = await request(query, {
-    entry,
-    operation,
-  });
-
-  return result.publish;
 }
 
 export async function getAllMushrooms(): Promise<MushroomResponse[]> {

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,10 +1,5 @@
 import { GraphQLClient, gql, RequestDocument } from 'graphql-request';
-import {
-  KeyPair,
-  OperationFields,
-  encodeOperation,
-  signAndEncodeEntry,
-} from 'p2panda-js';
+import { Session } from 'shirokuma';
 
 import { ENDPOINT, MUSHROOM_SCHEMA_ID, FINDINGS_SCHEMA_ID } from './constants';
 
@@ -29,26 +24,6 @@ async function request(query: RequestDocument, variables?: any) {
       'Error: Could not connect to node.\n\n- Did you start the node at port `2020`?\n- Did you deploy the schemas (via `npm run schema`) and changed the schema ids in `./src/constants.ts`?',
     );
   }
-}
-
-async function nextArgs(publicKey: string, viewId?: string): Promise<NextArgs> {
-  const query = gql`
-    query NextArgs($publicKey: String!, $viewId: String) {
-      nextArgs(publicKey: $publicKey, viewId: $viewId) {
-        logId
-        seqNum
-        backlink
-        skiplink
-      }
-    }
-  `;
-
-  const result = await request(query, {
-    publicKey,
-    viewId,
-  });
-
-  return result.nextArgs;
 }
 
 export async function publish(
@@ -119,52 +94,20 @@ export async function getMushroom(
 }
 
 export async function createMushroom(
-  keyPair: KeyPair,
+  session: Session,
   values: Mushroom,
 ): Promise<void> {
-  const args = await nextArgs(keyPair.publicKey());
-  const operation = encodeOperation({
-    schemaId: MUSHROOM_SCHEMA_ID,
-    fields: {
-      ...values,
-    },
-  });
-
-  const entry = signAndEncodeEntry(
-    {
-      ...args,
-      operation,
-    },
-    keyPair,
-  );
-
-  await publish(entry, operation);
+  await session.create(values, { schema: MUSHROOM_SCHEMA_ID });
 }
 
 export async function updateMushroom(
-  keyPair: KeyPair,
+  session: Session,
   previous: string,
   values: Mushroom,
 ): Promise<void> {
-  const args = await nextArgs(keyPair.publicKey(), previous);
-  const operation = encodeOperation({
-    action: 'update',
-    schemaId: MUSHROOM_SCHEMA_ID,
-    previous,
-    fields: {
-      ...values,
-    },
+  await session.update(values, previous.split('_'), {
+    schema: MUSHROOM_SCHEMA_ID,
   });
-
-  const entry = signAndEncodeEntry(
-    {
-      ...args,
-      operation,
-    },
-    keyPair,
-  );
-
-  await publish(entry, operation);
 }
 
 export async function getAllPictures(): Promise<PictureResponse[]> {
@@ -202,29 +145,6 @@ export async function getAllPictures(): Promise<PictureResponse[]> {
   return result.pictures.documents;
 }
 
-export async function createPicture(keyPair: KeyPair, values: Picture) {
-  const args = await nextArgs(keyPair.publicKey());
-  const { blob, lat, lon, mushrooms } = values;
-
-  const fields = new OperationFields({
-    blob,
-    lat,
-    lon,
-  });
-  fields.insert('mushrooms', 'relation_list', mushrooms);
-
-  const operation = encodeOperation({
-    schemaId: FINDINGS_SCHEMA_ID,
-    fields,
-  });
-
-  const entry = signAndEncodeEntry(
-    {
-      ...args,
-      operation,
-    },
-    keyPair,
-  );
-
-  await publish(entry, operation);
+export async function createPicture(session: Session, values: Picture) {
+  await session.create(values, { schema: FINDINGS_SCHEMA_ID });
 }

--- a/src/views/AddMushroom.tsx
+++ b/src/views/AddMushroom.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { Mushroom } from '../types';
 import { createMushroom } from '../requests';
 
 export const AddMushroom = () => {
   const navigate = useNavigate();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [values, setValues] = useState<Mushroom>({
     title: '',
@@ -31,7 +31,7 @@ export const AddMushroom = () => {
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await createMushroom(keyPair, values);
+    await createMushroom(session, values);
     window.alert('Created mushroom!');
     navigate('/mushrooms');
   };

--- a/src/views/EditMushroom.tsx
+++ b/src/views/EditMushroom.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { getMushroom, updateMushroom } from '../requests';
 import { Mushroom } from '../types';
 
 export const EditMushroom = () => {
   const navigate = useNavigate();
   const { documentId } = useParams();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [loading, setLoading] = useState(true);
   const [viewId, setViewId] = useState<string>();
@@ -46,7 +46,7 @@ export const EditMushroom = () => {
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await updateMushroom(keyPair, viewId, values);
+    await updateMushroom(session, viewId, values);
     window.alert('Updated mushroom!');
     navigate('/mushrooms');
   };

--- a/src/views/Pictures.tsx
+++ b/src/views/Pictures.tsx
@@ -34,16 +34,18 @@ export const Pictures = () => {
               <li key={meta.documentId}>
                 <img src={`data:${fields.blob}`} width="250" />
                 <ul>
-                  {fields.mushrooms.documents.map((mushroom: MushroomResponse) => {
-                    return (
-                      <li key={mushroom.meta.documentId}>
-                        <Link to={`/mushrooms/${mushroom.meta.documentId}`}>
-                          {mushroom.fields.title}{' '}
-                          <em>{mushroom.fields.latin}</em>
-                        </Link>
-                      </li>
-                    );
-                  })}
+                  {fields.mushrooms.documents.map(
+                    (mushroom: MushroomResponse) => {
+                      return (
+                        <li key={mushroom.meta.documentId}>
+                          <Link to={`/mushrooms/${mushroom.meta.documentId}`}>
+                            {mushroom.fields.title}{' '}
+                            <em>{mushroom.fields.latin}</em>
+                          </Link>
+                        </li>
+                      );
+                    },
+                  )}
                 </ul>
               </li>
             );

--- a/src/views/UploadPicture.tsx
+++ b/src/views/UploadPicture.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { KeyPairContext } from '../KeyPairContext';
+import { P2pandaContext } from '../P2pandaContext';
 import { Picture } from '../types';
 import { createPicture, getAllMushrooms } from '../requests';
 
 export const UploadPicture = () => {
   const navigate = useNavigate();
-  const { keyPair } = useContext(KeyPairContext);
+  const { session } = useContext(P2pandaContext);
 
   const [values, setValues] = useState<Picture>({
     blob: '',
@@ -59,7 +59,7 @@ export const UploadPicture = () => {
 
   const onSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    await createPicture(keyPair, values);
+    await createPicture(session, values);
     window.alert('Uploaded picture!');
     navigate('/pictures');
   };


### PR DESCRIPTION
Integrate the higher level p2panda lib `shirokuma`.

We shouldn't actually merge this to main as it would mess up the existing tutorial, but maybe there is a home for it elsewhere eventually.

- [x] `npm add shirokuma`
- [x] expose `Session` globally via context
- [x] use `session` to create and update documents in app
- [x] use `session` to publish the schema too
